### PR TITLE
Change charset in http headers from GBK to UTF-8

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ var host = "0.0.0.0";
 var port = process.env.PORT || 3000;
 
 http.createServer(function (req, res) {
-    res.writeHead(200, {'Content-Type': 'text/html;charset=GBK'});
+    res.writeHead(200, {'Content-Type': 'text/html;charset=UTF-8'});
     res.write('<h1>Hello from a node app! ');
     res.write('</h1>');
     res.write('<h2>');


### PR DESCRIPTION
This PR changes the charset in the HTTP headers from `GBK` to `UTF-8`.

When I cloned this repository, my files appear to be in the UTF-8 character encoding.  Both viewing the application running locally as well as pushing and viewing it from PCF resulted in mojibake for me.  Selecting "UTF-8" from my browser fixed the issue.

Here are a few screenshots:

**With GBK character encoding**:
<img width="595" alt="mojibake" src="https://cloud.githubusercontent.com/assets/1085165/17645600/02aa28c6-6170-11e6-9499-0a785066ef96.png">

**With UTF-8 character encoding**:
<img width="678" alt="correct" src="https://cloud.githubusercontent.com/assets/1085165/17645601/099298a8-6170-11e6-8a42-f957ef91b8b7.png">

Thanks!
